### PR TITLE
Fix AntPlus.io lock up when using with a Teensy 4.1

### DIFF
--- a/antplus.cpp
+++ b/antplus.cpp
@@ -181,6 +181,7 @@ size_t AntPlus::write(const void *data, const size_t size)
 		head = 0;
 	}
 	uint32_t avail;
+	uint8_t attempts = 100;
 	do {
 		uint32_t tail = txtail;
 		if (head > tail) {
@@ -188,7 +189,8 @@ size_t AntPlus::write(const void *data, const size_t size)
 		} else {
 			avail = tail - head;
 		}
-	} while (avail < size + 1); // wait for space in buffer
+		attempts--;
+	} while ((avail < size + 1) && attempts > 0 ); // wait for space in buffer
 	txbuffer[head] = size;
 	memcpy(txbuffer + head + 1, data, size);
 	txhead = head + size;


### PR DESCRIPTION
This fix was suggested by HRBF here: https://forum.pjrc.com/threads/43110-Ant-libarary-and-USB-driver-for-Teensy-3-5-6?p=272817&viewfull=1#post272817 . I noticed the same lockup when I attempted to run the AntPlus.io as well while running the code on a Teensy 4.1. This fixed the issue for me as well.